### PR TITLE
Add DNS Entitlements, Data Model, Default Server Logic, Management Service, and UI Updates

### DIFF
--- a/DNSwitch.xcodeproj/project.pbxproj
+++ b/DNSwitch.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = DNSwitch/DNSecure.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"DNSwitch/Preview Content\"";
@@ -278,6 +279,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = DNSwitch/DNSecure.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"DNSwitch/Preview Content\"";

--- a/DNSwitch/DNSecure.entitlements
+++ b/DNSwitch/DNSecure.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.networking.networkextension</key>
+	<array>
+		<string>dns-settings</string>
+	</array>
+	<key>com.apple.developer.networking.wifi-info</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/DNSwitch/Extensions/DNSServer+WillSave.swift
+++ b/DNSwitch/Extensions/DNSServer+WillSave.swift
@@ -1,0 +1,32 @@
+//
+//  DNSServer+WillSave.swift
+//  DNSwitch
+//
+//  Created by kryx on 2025/03/08.
+//
+
+import Foundation
+import CoreData
+
+extension DNSServer {
+    
+    override public func willSave() {
+        super.willSave()
+        
+        // ensure no other server remains marked as default.
+        if isDefault {
+            if let context = self.managedObjectContext {
+                let fetchRequest: NSFetchRequest<DNSServer> = DNSServer.fetchRequest()
+                fetchRequest.predicate = NSPredicate(format: "isDefault == YES AND self != %@", self)
+                do {
+                    let otherDefaults = try context.fetch(fetchRequest)
+                    for server in otherDefaults {
+                        server.isDefault = false
+                    }
+                } catch {
+                    print("Failed to fetch default servers: \(error)")
+                }
+            }
+        }
+    }
+}

--- a/DNSwitch/Helpers/DNSDataSeeder.swift
+++ b/DNSwitch/Helpers/DNSDataSeeder.swift
@@ -35,7 +35,6 @@ func createSampleDNSServers(in context: NSManagedObjectContext) {
         name: "AdGuard",
         ipv4: ["94.140.14.14", "94.140.15.15"],
         ipv6: ["2a10:50c0::ad1:ff", "2a10:50c0::ad2:ff"],
-        // Using a custom URL scheme for DoT. Adjust or set to nil if not needed.
         serverURL: URL(string: "tls://dns.adguard.com"),
         port: 853,
         protocolType: .dot
@@ -47,7 +46,6 @@ func createSampleDNSServers(in context: NSManagedObjectContext) {
         name: "AdGuard",
         ipv4: ["94.140.14.14", "94.140.15.15"],
         ipv6: ["2a10:50c0::ad1:ff", "2a10:50c0::ad2:ff"],
-        // Using a custom URL scheme for DoT. Adjust or set to nil if not needed.
         serverURL: URL(string: "https://dns.adguard-dns.com/dns-query"),
         port: 443,
         protocolType: .doh

--- a/DNSwitch/Model/DNSwitch.xcdatamodeld/DNSwitch.xcdatamodel/contents
+++ b/DNSwitch/Model/DNSwitch.xcdatamodeld/DNSwitch.xcdatamodel/contents
@@ -2,16 +2,17 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24D70" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="DNSRule" representedClassName="DNSRule" syncable="YES" codeGenerationType="class">
         <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="priority" optional="YES" attributeType="Integer 16" minValueString="0" maxValueString="10" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="priority" attributeType="Integer 16" minValueString="0" maxValueString="10" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="ssidMatch" optional="YES" attributeType="String"/>
         <relationship name="server" maxCount="1" deletionRule="Cascade" destinationEntity="DNSServer" inverseName="rules" inverseEntity="DNSServer"/>
     </entity>
     <entity name="DNSServer" representedClassName="DNSServer" syncable="YES" codeGenerationType="class">
-        <attribute name="ipv4" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
-        <attribute name="ipv6" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
-        <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="port" optional="YES" attributeType="Integer 16" defaultValueString="53" usesScalarValueType="YES"/>
-        <attribute name="protocolType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ipv4" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="ipv6" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
+        <attribute name="isDefault" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString="Unnamed Server"/>
+        <attribute name="port" attributeType="Integer 16" defaultValueString="53" usesScalarValueType="YES"/>
+        <attribute name="protocolType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="serverURL" optional="YES" attributeType="URI"/>
         <relationship name="rules" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="DNSRule" inverseName="server" inverseEntity="DNSRule"/>
         <relationship name="serverFallbacks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ServerFallback" inverseName="primary" inverseEntity="ServerFallback"/>

--- a/DNSwitch/Services/DNSManagementService.swift
+++ b/DNSwitch/Services/DNSManagementService.swift
@@ -1,0 +1,88 @@
+//
+//  DNSManagementService.swift
+//  DNSwitch
+//
+//  Created by kryx on 2025/03/08.
+//
+
+import Foundation
+import NetworkExtension
+
+
+class DNSManagementService {
+    static let shared = DNSManagementService()
+    
+    private init() {}
+    
+    /// Configures the system DNS settings using the given DNSServer.
+    /// - Parameters:
+    ///   - server: The DNSServer instance containing the DNS configuration data.
+    ///   - completion: Called with an optional error once the operation completes.
+    func configureDefaultDNS(with server: DNSServer, completion: @escaping (Error?) -> Void) {
+        let dnsManager = NEDNSSettingsManager.shared()
+        
+        dnsManager.loadFromPreferences { loadError in
+            if let loadError = loadError {
+                completion(loadError)
+                return
+            }
+            
+            var dnsSettings: NEDNSSettings?
+            // Use IPv4 addresses as the server list.
+            let ipv4Servers = server.ipv4 as? [String] ?? []
+            
+            switch server.protocolTypeEnum {
+            case .doh:
+                // DNS-over-HTTPS configuration
+                guard let serverURL = server.serverURL else {
+                    let error = NSError(
+                        domain: "DNSManagementService",
+                        code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "Missing server URL for DoH configuration."]
+                    )
+                    completion(error)
+                    return
+                }
+                let dohSettings = NEDNSOverHTTPSSettings(servers: ipv4Servers)
+                dohSettings.serverURL = serverURL
+                dnsSettings = dohSettings
+                
+            case .dot:
+                // DNS-over-TLS configuration
+                let dotSettings = NEDNSOverTLSSettings(servers: ipv4Servers)
+                // Attempt to extract the hostname from the URL (e.g., "dns.adguard.com")
+                if let host = server.serverURL?.host {
+                    dotSettings.serverName = host
+                } else {
+                    dotSettings.serverName = server.name // fallback if URL isn't available
+                }
+                dnsSettings = dotSettings
+                
+            default:
+                // Fallback: if serverURL is provided, use DoH; otherwise, use DoT.
+                if let serverURL = server.serverURL {
+                    let dohSettings = NEDNSOverHTTPSSettings(servers: ipv4Servers)
+                    dohSettings.serverURL = serverURL
+                    dnsSettings = dohSettings
+                } else {
+                    let dotSettings = NEDNSOverTLSSettings(servers: ipv4Servers)
+                    dotSettings.serverName = server.name
+                    dnsSettings = dotSettings
+                }
+            }
+            
+            // Update the DNS settings manager with the new settings.
+            dnsManager.dnsSettings = dnsSettings
+            dnsManager.localizedDescription = server.name
+            
+            dnsManager.saveToPreferences { saveError in
+                if let saveError = saveError {
+                    print("Error saving DNS configuration: \(saveError)")
+                } else {
+                    print("Default DNS configuration updated.")
+                }
+                completion(saveError)
+            }
+        }
+    }
+}

--- a/DNSwitch/Views/DNSServerDetailView.swift
+++ b/DNSwitch/Views/DNSServerDetailView.swift
@@ -1,0 +1,62 @@
+//
+//  DNSServerDetailView.swift
+//  DNSwitch
+//
+//  Created by kryx on 2025/03/08.
+//
+
+
+import SwiftUI
+import CoreData
+
+struct DNSServerDetailView: View {
+    @ObservedObject var server: DNSServer
+
+    var body: some View {
+        Form {
+            Toggle("Use Server", isOn: $server.isDefault)
+                .onChange(of: server.isDefault) { oldValue, newValue in
+                    setDefaultServer()
+                }
+        }
+        .navigationTitle(server.name!)
+    }
+    
+    private func setDefaultServer() {
+        do {
+            try server.managedObjectContext?.save()
+        } catch {
+            print("Error saving default server: \(error)")
+        }
+        
+        DNSManagementService.shared.configureDefaultDNS(with: server) { error in
+            if let error = error {
+                print("Error configuring default DNS: \(error)")
+            } else {
+                print("Default DNS configuration updated.")
+            }
+        }
+    }
+    
+}
+
+struct DNSServerDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+
+        let viewContext = PersistenceController.preview.container.viewContext
+        let server = DNSServer(
+            context: viewContext,
+            name: "Cloudflare",
+            ipv4: ["1.1.1.1", "1.0.0.1"],
+            ipv6: ["2606:4700:4700::1111", "2606:4700:4700::1001"],
+            serverURL: URL(string: "https://cloudflare-dns.com/dns-query"),
+            port: 443,
+            protocolType: .doh
+        )
+        
+        return NavigationView {
+            DNSServerDetailView(server: server)
+                .environment(\.managedObjectContext, viewContext)
+        }
+    }
+}

--- a/DNSwitch/Views/DNSServerView.swift
+++ b/DNSwitch/Views/DNSServerView.swift
@@ -9,12 +9,18 @@
 import SwiftUI
 
 struct DNSServerView: View {
-    var server: DNSServer
+    @ObservedObject var server: DNSServer
 
     var body: some View {
         HStack {
+            if server.isDefault {
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: 10, height: 10)
+                    .padding(.trailing, 8)
+            }
             VStack(alignment: .leading, spacing: 2) {
-                Text(server.name ?? "Unnamed Server")
+                Text(server.name!)
                     .font(.headline)
                 Text(server.protocolTypeDescription)
                     .font(.subheadline)

--- a/DNSwitch/Views/DNSServersListView.swift
+++ b/DNSwitch/Views/DNSServersListView.swift
@@ -14,9 +14,13 @@ struct DNSServersListView: View {
 
     @FetchRequest(
         entity: DNSServer.entity(),
-        sortDescriptors: [NSSortDescriptor(keyPath: \DNSServer.name, ascending: true)],
+        sortDescriptors: [
+            // Sort by isDefault descending so that the default server appears at the top,
+            // then by name ascending.
+            NSSortDescriptor(keyPath: \DNSServer.isDefault, ascending: false),
+            NSSortDescriptor(keyPath: \DNSServer.name, ascending: true)
+        ],
         animation: .default)
-    
     private var servers: FetchedResults<DNSServer>
 
     var body: some View {
@@ -25,8 +29,7 @@ struct DNSServersListView: View {
                 Section(header: Text("Servers").font(.headline).padding(.vertical, 4)) {
                     ForEach(servers) { server in
                         NavigationLink {
-                            Text("Detail view for \(server.name ?? "Unnamed Server")")
-                                .navigationTitle(server.name ?? "Server Details")
+                            DNSServerDetailView(server: server)
                         } label: {
                             DNSServerView(server: server)
                         }


### PR DESCRIPTION

- Entitlements & Data Model: Added DNSecure entitlements, updated Core Data model with isDefault flag, and refined sample data seeding.
- Default Server Enforcement: Implemented logic (willSave) to ensure only one DNS server is marked default.
- DNS Management Service: Created DNSManagementService to manage and apply DNS configurations using NetworkExtension APIs (DoH/DoT).
- UI Enhancements: Updated server detail views and server list to visually indicate and manage the default DNS server.